### PR TITLE
docs: buffer donation now works on cpu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ train_state, buffer_state = jax.jit(train, donate_argnums=(1,))(
 )
 ```
 
-It is important to include `donate_argnums` when calling `jax.jit` to enable JAX to perform an in-place update of the replay buffer state. Omitting `donate_argnums` would force JAX to create a copy of the state for any modifications to the replay buffer state, potentially negating all performance benefits. More information about buffer donation in JAX can be found in the [documentation](https://jax.readthedocs.io/en/latest/faq.html#buffer-donation). Please take into account that buffer donation is not applicable on the CPU.
+It is important to include `donate_argnums` when calling `jax.jit` to enable JAX to perform an in-place update of the replay buffer state. Omitting `donate_argnums` would force JAX to create a copy of the state for any modifications to the replay buffer state, potentially negating all performance benefits. More information about buffer donation in JAX can be found in the [documentation](https://jax.readthedocs.io/en/latest/faq.html#buffer-donation).
 
 In summary, understanding and addressing these considerations will help you navigate potential pitfalls and ensure the effectiveness of your reinforcement learning strategies while utilising Flashbax buffers.
 


### PR DESCRIPTION
Buffer donation was previously constrained to GPU/TPU, but no longer 🎉  As discovered in the discussions of #6.