### PR TITLE
fix: incorrect current index.

### DIFF
--- a/flashbax/vault/vault.py
+++ b/flashbax/vault/vault.py
@@ -478,6 +478,6 @@ class Vault:
         # Return the read result as a fbx buffer state
         return TrajectoryBufferState(
             experience=read_result,
-            current_index=jnp.array(self.vault_index, dtype=int),
+            current_index=jnp.array(0, dtype=int),
             is_full=jnp.array(True, dtype=bool),
         )


### PR DESCRIPTION
Coming from discussions in #16. I think we should spend more time on _that_ PR, deciding how we want the `read` API to look.

But in the interim, there is definitely a bug in the current index of the fbx buffer returned by a vault read—thanks @EdanToledo! Let's fix that now :)