### PR TITLE
Fix Jumanji environment spec access in examples

### DIFF
--- a/examples/anakin_dqn_example.ipynb
+++ b/examples/anakin_dqn_example.ipynb
@@ -310,7 +310,7 @@
     "):\n",
     "    \"\"\"Sets up the experiment.\"\"\"\n",
     "    cores_count = len(jax.devices())  # get available TPU cores.\n",
-    "    network = get_network_fn(env.action_spec().num_values)  # define network.\n",
+    "    network = get_network_fn(env.action_spec.num_values)  # define network.\n",
     "    optim = optax.adam(step_size)  # define optimiser.\n",
     "\n",
     "    rng, rng_e, rng_p = random.split(random.PRNGKey(seed), num=3)  # prng keys.\n",

--- a/examples/anakin_ppo_example.ipynb
+++ b/examples/anakin_ppo_example.ipynb
@@ -253,7 +253,7 @@
     "    \"\"\"Sets up the experiment and returns the necessary information.\"\"\"\n",
     "\n",
     "    cores_count = len(jax.devices())  # get available TPU cores.\n",
-    "    network = get_network_fn(env.action_spec().num_values)  # define network.\n",
+    "    network = get_network_fn(env.action_spec.num_values)  # define network.\n",
     "    optim = optax.adam(step_size)  # define optimiser.\n",
     "\n",
     "    rng, rng_e, rng_p = random.split(random.PRNGKey(seed), num=3)  # prng keys.\n",

--- a/examples/anakin_prioritised_dqn_example.ipynb
+++ b/examples/anakin_prioritised_dqn_example.ipynb
@@ -333,7 +333,7 @@
     "):\n",
     "    \"\"\"Sets up the experiment.\"\"\"\n",
     "    cores_count = len(jax.devices())  # get available TPU cores.\n",
-    "    network = get_network_fn(env.action_spec().num_values)  # define network.\n",
+    "    network = get_network_fn(env.action_spec.num_values)  # define network.\n",
     "    optim = optax.adam(step_size)  # define optimiser.\n",
     "\n",
     "    rng, rng_e, rng_p = random.split(random.PRNGKey(seed), num=3)  # prng keys.\n",


### PR DESCRIPTION
Jumanji turned specs into cached properties making them non-callable: https://github.com/instadeepai/jumanji/commit/1f38fe669c31d0f41a51e23ff02e74e300bb89c9
This PR fixes the example notebooks by updating the `set_up_experiment` function accordingly.