### PR TITLE
fix: be explicit about squeeze dim in prioritised sampling to avoid flattening (1,1) arrays

### DIFF
--- a/flashbax/buffers/sum_tree.py
+++ b/flashbax/buffers/sum_tree.py
@@ -208,7 +208,7 @@ def stratified_sample(
     )
 
     return jax.vmap(sample, in_axes=(None, None, 0))(
-        state, None, query_values.squeeze()
+        state, None, query_values.squeeze(axis=-1)
     )
 
 


### PR DESCRIPTION
Currently, the following snippet will fail:
```py
from flashbax import make_prioritised_flat_buffer
import jax
import jax.numpy as jnp

buffer = make_prioritised_flat_buffer(
    max_length=100,
    min_length=1,
    sample_batch_size=1,  # NB
    add_sequences=False,
)

timestep = {"obs": jnp.zeros(shape=(3)),}

state = buffer.init(timestep)

for i in range(5):
    timestep = {
        "obs": jnp.ones(shape=(3)) * i,
    }
    state = buffer.add(state, timestep)

buffer.sample(state, jax.random.PRNGKey(0))
```

because of this line:
https://github.com/instadeepai/flashbax/blob/b556e15cb8d7ff3cd39349a062dd484a8ce57244/flashbax/buffers/sum_tree.py#L211

If the `sample_batch_size` is 1, `query_values` is shape `(1,1)`, which squeezes to `()`.

Instead we must be explicit about the squeeze dim.
