### PR TITLE
feat: simple utility to get timestep count

### DIFF
--- a/flashbax/utils.py
+++ b/flashbax/utils.py
@@ -68,3 +68,22 @@ def add_dim_to_args(
         return func(*args, **kwargs)
 
     return wrapper
+
+
+def get_timestep_count(buffer_state: chex.ArrayTree) -> int:
+    """Utility to compute the total number of timesteps currently in the buffer state.
+
+    Args:
+        buffer_state (BufferStateTypes): the buffer state to compute the total timesteps for.
+
+    Returns:
+        int: the total number of timesteps in the buffer state.
+    """
+    # Ensure the buffer state is a valid buffer state.
+    assert hasattr(buffer_state, "experience")
+    assert hasattr(buffer_state, "current_index")
+    assert hasattr(buffer_state, "is_full")
+
+    b_size, t_size_max = get_tree_shape_prefix(buffer_state.experience, 2)
+    t_size = t_size_max if buffer_state.is_full else buffer_state.current_index
+    return int(b_size * t_size)

--- a/flashbax/utils.py
+++ b/flashbax/utils.py
@@ -85,5 +85,10 @@ def get_timestep_count(buffer_state: chex.ArrayTree) -> int:
     assert hasattr(buffer_state, "is_full")
 
     b_size, t_size_max = get_tree_shape_prefix(buffer_state.experience, 2)
-    t_size = t_size_max if buffer_state.is_full else buffer_state.current_index
-    return int(b_size * t_size)
+    t_size = jax.lax.cond(
+        buffer_state.is_full,
+        lambda: t_size_max,
+        lambda: buffer_state.current_index,
+    )
+    timestep_count: int = b_size * t_size
+    return timestep_count


### PR DESCRIPTION
From discussions in #33.

Demo:
```py
import flashbax as fbx
import jax.numpy as jnp
from flashbax.utils import get_timestep_count

buffer = fbx.make_flat_buffer(
    max_length=10,
    min_length=1,
    sample_batch_size=1,
    add_batch_size=2,
    add_sequences=False,
)

timestep = {"obs": jnp.array([1.0])}

state = buffer.init(timestep)

for i in range(10):
    timestep = {
        "obs": jnp.tile(jnp.array([i], dtype=jnp.float32), (2, 1)),
    }
    state = buffer.add(state, timestep)

    print("Timestep count =", get_timestep_count(state))
```

Output:
```sh
Timestep count = 2
Timestep count = 4
Timestep count = 6
Timestep count = 8
Timestep count = 10
Timestep count = 10
Timestep count = 10
Timestep count = 10
Timestep count = 10
Timestep count = 10
```