### PR TITLE
chore: use gh hosted runners for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: instadeep-ci
+    runs-on: ubuntu:latest
     container:
       image: ghcr.io/catthehacker/ubuntu:runner-latest
     timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: instadeep-ci
+    container:
+      image: ghcr.io/catthehacker/ubuntu:runner-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/catthehacker/ubuntu:runner-latest
     timeout-minutes: 30

--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -4,25 +4,22 @@ on: [ push, pull_request ]
 
 jobs:
   tests-and-linters:
-    name: "Python ${{ matrix.python-version }} on ${{ matrix.os }}"
-    runs-on: "${{ matrix.os }}"
-
-    strategy:
-      matrix:
-        python-version: ["3.9"]
-        os: ["instadeep-ci"]
+    name: "Python 3.9 on instadeep-ci"
+    runs-on: instadeep-ci
     container:
         image: python:3.9
 
     steps:
       - name: Install dependencies for viewer test
-        run: sudo apt-get update && sudo apt-get install -y xvfb
+        run: apt-get update && apt-get install -y xvfb
       - name: Checkout flashbax
         uses: actions/checkout@v3
       - name: Install python dependencies 🔧
         run: pip install .[dev]
       - name: List python packages 📦
         run: pip list
+      # Workaround for https://github.com/actions/checkout/issues/1169
+      - run: git config --system --add safe.directory $GITHUB_WORKSPACE
       - name: Run linters 🖌️
         run: pre-commit run --all-files --verbose
       - name: Run tests 🧪

--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -18,8 +18,6 @@ jobs:
         run: pip install .[dev]
       - name: List python packages 📦
         run: pip list
-      - name: Check git settings
-        run: git --version
       - name: Run linters 🖌️
         run: pre-commit run --all-files --verbose
       - name: Run tests 🧪
@@ -28,3 +26,6 @@ jobs:
         run: |
           coverage html --directory=coverage_html_report
           coverage report --fail-under=0.97
+      - name: Print pre-commit log on failure
+        if: failure()
+        run: cat /github/home/.cache/pre-commit/pre-commit.log

--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -18,6 +18,8 @@ jobs:
         run: pip install .[dev]
       - name: List python packages 📦
         run: pip list
+      - name: Update git permissions
+        run: git config --global --add safe.directory /__w/flashbax/flashbax
       - name: Run linters 🖌️
         run: pre-commit run --all-files --verbose
       - name: Run tests 🧪
@@ -26,6 +28,3 @@ jobs:
         run: |
           coverage html --directory=coverage_html_report
           coverage report --fail-under=0.97
-      - name: Print pre-commit log on failure
-        if: failure()
-        run: cat /github/home/.cache/pre-commit/pre-commit.log

--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        os: [self-hosted]
+        os: [instadeep-ci]
 
     steps:
       - name: Install dependencies for viewer test

--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -10,16 +10,15 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        os: [instadeep-ci]
+        os: ["instadeep-ci"]
+    container:
+        image: python:3.9
 
     steps:
       - name: Install dependencies for viewer test
         run: sudo apt-get update && sudo apt-get install -y xvfb
       - name: Checkout flashbax
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-            python-version: "${{ matrix.python-version }}"
       - name: Install python dependencies 🔧
         run: pip install .[dev]
       - name: List python packages 📦

--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -5,7 +5,7 @@ on: [ push, pull_request ]
 jobs:
   tests-and-linters:
     name: "Python 3.9 on instadeep-ci"
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
     container:
         image: python:3.9
 

--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   tests-and-linters:
-    name: "Python 3.9 on instadeep-ci"
+    name: "Python 3.9 on GitHub Hosted runner"
     runs-on: ubuntu-latest
     container:
         image: python:3.9
@@ -18,8 +18,6 @@ jobs:
         run: pip install .[dev]
       - name: List python packages 📦
         run: pip list
-      # Workaround for https://github.com/actions/checkout/issues/1169
-      - run: git config --system --add safe.directory $GITHUB_WORKSPACE
       - name: Run linters 🖌️
         run: pre-commit run --all-files --verbose
       - name: Run tests 🧪

--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -5,7 +5,7 @@ on: [ push, pull_request ]
 jobs:
   tests-and-linters:
     name: "Python 3.9 on instadeep-ci"
-    runs-on: instadeep-ci
+    runs-on: ubuntu:latest
     container:
         image: python:3.9
 

--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -11,13 +11,15 @@ jobs:
 
     steps:
       - name: Install dependencies for viewer test
-        run: apt-get update && apt-get install -y xvfb git
+        run: apt-get update && apt-get install -y xvfb
       - name: Checkout flashbax
         uses: actions/checkout@v3
       - name: Install python dependencies 🔧
         run: pip install .[dev]
       - name: List python packages 📦
         run: pip list
+      - name: Check git settings
+        run: git --version
       - name: Run linters 🖌️
         run: pre-commit run --all-files --verbose
       - name: Run tests 🧪

--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Install dependencies for viewer test
-        run: apt-get update && apt-get install -y xvfb
+        run: apt-get update && apt-get install -y xvfb git
       - name: Checkout flashbax
         uses: actions/checkout@v3
       - name: Install python dependencies 🔧

--- a/flashbax/buffers/prioritised_trajectory_buffer.py
+++ b/flashbax/buffers/prioritised_trajectory_buffer.py
@@ -798,6 +798,7 @@ def make_prioritised_trajectory_buffer(
     if max_size is not None:
         max_length_time_axis = max_size // add_batch_size
 
+    assert max_length_time_axis is not None
     init_fn = functools.partial(
         prioritised_init,
         add_batch_size=add_batch_size,

--- a/flashbax/buffers/trajectory_buffer.py
+++ b/flashbax/buffers/trajectory_buffer.py
@@ -585,6 +585,7 @@ def make_trajectory_buffer(
     if max_size is not None:
         max_length_time_axis = max_size // add_batch_size
 
+    assert max_length_time_axis is not None
     init_fn = functools.partial(
         init,
         add_batch_size=add_batch_size,


### PR DESCRIPTION
CI jobs were no longer being picked up by self-hosted runners. I was told by @vikranth-t that we must now use gh hosted runners for public repos.