### PR TITLE
Treat warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,15 @@ build-backend = "hatchling.build"
 [tool.hatch.build]
 include = ["flashbax/*"]
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+    "ignore:`sample_sequence_length` greater than `min_length_time_axis`:UserWarning:flashbax",
+    "ignore:Setting period greater than sample_sequence_length will result in no overlap betweentrajectories:UserWarning:flashbax",
+    "ignore:Setting max_size dynamically sets the `max_length_time_axis` to be `max_size`//`add_batch_size = .*`:UserWarning:flashbax",
+    "ignore:jax.tree_map is deprecated:DeprecationWarning:flashbax",
+]
+
 [project]
 name = "flashbax"
 description = "Flashbax is an experience replay library oriented around JAX. Tailored to integrate seamlessly with JAX's Just-In-Time (JIT) compilation."


### PR DESCRIPTION
Will write follow ups to try and address the warnings that were ignored.