### PR TITLE
Address `sample_sequence_length` greater than `min_length_time_axis`

### DIFF
--- a/flashbax/buffers/flat_buffer_test.py
+++ b/flashbax/buffers/flat_buffer_test.py
@@ -76,7 +76,7 @@ def test_sample(
     rng_key1, rng_key2 = jax.random.split(rng_key)
 
     # Fill buffer to the point that we can sample
-    fake_batch = get_fake_batch(fake_transition, int(min_length + 10))
+    fake_batch = get_fake_batch(fake_transition, min_length)
 
     buffer = flat_buffer.make_flat_buffer(
         max_length, min_length, sample_batch_size, False, add_batch_size=min_length

--- a/flashbax/buffers/flat_buffer_test.py
+++ b/flashbax/buffers/flat_buffer_test.py
@@ -78,8 +78,9 @@ def test_sample(
     # Fill buffer to the point that we can sample
     fake_batch = get_fake_batch(fake_transition, int(min_length + 10))
 
+    add_batch_size = int(min_length + 10)
     buffer = flat_buffer.make_flat_buffer(
-        max_length, min_length, sample_batch_size, False, int(min_length + 10)
+        max_length, add_batch_size, sample_batch_size, False, add_batch_size
     )
     state = buffer.init(fake_transition)
 
@@ -224,7 +225,7 @@ def test_flat_replay_buffer_does_not_smoke(
 
     add_batch_size = int(min_length + 5)
     buffer = flat_buffer.make_flat_buffer(
-        max_length, min_length, sample_batch_size, False, add_batch_size
+        max_length, add_batch_size, sample_batch_size, False, add_batch_size
     )
 
     # Initialise the buffer's state.

--- a/flashbax/buffers/flat_buffer_test.py
+++ b/flashbax/buffers/flat_buffer_test.py
@@ -78,9 +78,8 @@ def test_sample(
     # Fill buffer to the point that we can sample
     fake_batch = get_fake_batch(fake_transition, int(min_length + 10))
 
-    add_batch_size = int(min_length + 10)
     buffer = flat_buffer.make_flat_buffer(
-        max_length, add_batch_size, sample_batch_size, False, add_batch_size
+        max_length, min_length, sample_batch_size, False, add_batch_size=min_length
     )
     state = buffer.init(fake_transition)
 
@@ -223,9 +222,8 @@ def test_flat_replay_buffer_does_not_smoke(
 ):
     """Create the FlatBuffer NamedTuple, and check that it is pmap-able and does not smoke."""
 
-    add_batch_size = int(min_length + 5)
     buffer = flat_buffer.make_flat_buffer(
-        max_length, add_batch_size, sample_batch_size, False, add_batch_size
+        max_length, min_length, sample_batch_size, False, add_batch_size=min_length
     )
 
     # Initialise the buffer's state.
@@ -237,7 +235,7 @@ def test_flat_replay_buffer_does_not_smoke(
     # Now fill the buffer above its minimum length.
 
     fake_batch = jax.pmap(get_fake_batch, static_broadcasted_argnums=1)(
-        fake_transition_per_device, add_batch_size
+        fake_transition_per_device, min_length
     )
     # Add two items thereby giving a single transition.
     state = jax.pmap(buffer.add)(state, fake_batch)

--- a/flashbax/buffers/mixer_test.py
+++ b/flashbax/buffers/mixer_test.py
@@ -92,7 +92,7 @@ def test_mixed_trajectory_sample(
     for i in range(3):
         buffer = trajectory_buffer.make_trajectory_buffer(
             max_length_time_axis=200 * (i + 1),
-            min_length_time_axis=0,
+            min_length_time_axis=sample_sequence_length,
             sample_batch_size=sample_batch_size,
             add_batch_size=add_batch_size,
             sample_sequence_length=sample_sequence_length,
@@ -143,7 +143,7 @@ def test_mixed_prioritised_trajectory_sample(
     for i in range(3):
         buffer = prioritised_trajectory_buffer.make_prioritised_trajectory_buffer(
             max_length_time_axis=200 * (i + 1),
-            min_length_time_axis=0,
+            min_length_time_axis=sample_sequence_length,
             sample_batch_size=sample_batch_size,
             add_batch_size=add_batch_size,
             sample_sequence_length=sample_sequence_length,
@@ -192,7 +192,7 @@ def test_mixed_flat_buffer_sample(
     for i in range(3):
         buffer = flat_buffer.make_flat_buffer(
             max_length=200 * (i + 1),
-            min_length=0,
+            min_length=add_batch_size,
             sample_batch_size=sample_batch_size,
             add_batch_size=add_batch_size,
             add_sequences=True,
@@ -241,7 +241,7 @@ def test_mixed_buffer_does_not_smoke(
     for i in range(3):
         buffer = trajectory_buffer.make_trajectory_buffer(
             max_length_time_axis=2000 * (i + 1),
-            min_length_time_axis=0,
+            min_length_time_axis=sample_sequence_length,
             sample_batch_size=sample_batch_size,
             add_batch_size=add_batch_size,
             sample_sequence_length=sample_sequence_length,

--- a/flashbax/buffers/prioritised_flat_buffer_test.py
+++ b/flashbax/buffers/prioritised_flat_buffer_test.py
@@ -90,7 +90,7 @@ def test_sample(
     fake_batch = get_fake_batch(fake_transition, add_batch_size)
 
     buffer = prioritised_flat_buffer.make_prioritised_flat_buffer(
-        max_length, min_length, sample_batch_size, False, add_batch_size
+        max_length, add_batch_size, sample_batch_size, False, add_batch_size
     )
     state = buffer.init(fake_transition)
 
@@ -137,7 +137,7 @@ def test_adjust_priorities(
     fake_batch = get_fake_batch(fake_transition, add_batch_size)
     buffer = prioritised_flat_buffer.make_prioritised_flat_buffer(
         max_length,
-        min_length,
+        add_batch_size,
         sample_batch_size,
         False,
         add_batch_size,
@@ -179,7 +179,7 @@ def test_prioritised_flat_buffer_does_not_smoke(
 
     buffer = prioritised_flat_buffer.make_prioritised_flat_buffer(
         max_length,
-        min_length,
+        add_batch_size,
         sample_batch_size,
         False,
         add_batch_size,
@@ -313,7 +313,6 @@ def test_add_sequences(
 
 def test_add_sequences_and_batches(
     fake_transition: chex.ArrayTree,
-    min_length: int,
     max_length: int,
     add_batch_size: int,
     sample_batch_size: int,
@@ -329,7 +328,7 @@ def test_add_sequences_and_batches(
 
     buffer = prioritised_flat_buffer.make_prioritised_flat_buffer(
         max_length,
-        min_length,
+        add_batch_size,
         sample_batch_size,
         add_sequences=True,
         add_batch_size=add_batch_size,

--- a/flashbax/buffers/trajectory_buffer_test.py
+++ b/flashbax/buffers/trajectory_buffer_test.py
@@ -165,7 +165,7 @@ def test_add_sample_max_capacity(
     sample_sequence_length = add_sequence_length
     buffer = trajectory_buffer.make_trajectory_buffer(
         max_length_time_axis=add_sequence_length,
-        min_length_time_axis=0,
+        min_length_time_axis=sample_sequence_length,
         sample_batch_size=sample_batch_size,
         add_batch_size=add_batch_size,
         sample_sequence_length=sample_sequence_length,
@@ -342,7 +342,7 @@ def test_uniform_index_cal(
 
     buffer = trajectory_buffer.make_trajectory_buffer(
         max_length_time_axis=max_length,
-        min_length_time_axis=0,
+        min_length_time_axis=sample_sequence_length,
         sample_batch_size=sample_batch_size,
         add_batch_size=add_batch_size,
         sample_sequence_length=sample_sequence_length,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ include = ["flashbax/*"]
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
-    "ignore:`sample_sequence_length` greater than `min_length_time_axis`:UserWarning:flashbax",
     "ignore:Setting period greater than sample_sequence_length will result in no overlap betweentrajectories:UserWarning:flashbax",
     "ignore:jax.tree_map is deprecated:DeprecationWarning:flashbax",
 ]


### PR DESCRIPTION
Based on #43, please review that first and if it wasn't merged yet, please review this PR per commit. 

The goal of this PR is to make the tests not generate flashbax warnings and to prevent code from being added that would trigger a flashbax warning.

I am not sure that the suggested changes in the [last commit](https://github.com/instadeepai/flashbax/tree/8e2afc77323d8cf7cc9d835666566e2ce2524a85) are right.

I am unsure why `min_length_time_axis=min_length // add_batch_size + 1` is used in the trajectory buffer source code, particularly the `+ 1`. I am also unsure why the `min_length` fixture is defined as:

```
@pytest.fixture
def min_length(sample_batch_size: int) -> int:
    return int(sample_batch_size + 1)
```

I could understand if it was defined in terms of `add_batch_size`, but it is not. 