### PR TITLE
refactor: remove redundant make_*_buffer functions and rename create_*_buffer to make_*_buffer functions

### DIFF
--- a/flashbax/buffers/flat_buffer.py
+++ b/flashbax/buffers/flat_buffer.py
@@ -75,12 +75,12 @@ def validate_flat_buffer_args(
     validate_max_length_add_batch_size(max_length, add_batch_size)
 
 
-def create_flat_buffer(
+def make_flat_buffer(
     max_length: int,
     min_length: int,
     sample_batch_size: int,
-    add_sequences: bool,
-    add_batch_size: Optional[int],
+    add_sequences: bool = False,
+    add_batch_size: Optional[int] = None,
 ) -> TrajectoryBuffer:
     """Creates a trajectory buffer that acts as a flat buffer.
 
@@ -143,35 +143,3 @@ def create_flat_buffer(
         return TransitionSample(experience=ExperiencePair(first=first, second=second))
 
     return buffer.replace(add=add_fn, sample=sample_fn)  # type: ignore
-
-
-def make_flat_buffer(
-    max_length: int,
-    min_length: int,
-    sample_batch_size: int,
-    add_sequences: bool = False,
-    add_batch_size: Optional[int] = None,
-) -> TrajectoryBuffer:
-    """Makes a trajectory buffer act as a flat buffer.
-
-    Args:
-        max_length (int): The maximum length of the buffer.
-        min_length (int): The minimum length of the buffer.
-        sample_batch_size (int): The batch size of the samples.
-        add_sequences (Optional[bool], optional): Whether data is being added in sequences
-            to the buffer. If False, single transitions are being added each time add
-            is called. Defaults to False.
-        add_batch_size (Optional[int], optional): If adding data in batches, what is the
-            batch size that is being added each time. If None, single transitions or single
-            sequences are being added each time add is called. Defaults to None.
-
-    Returns:
-        The buffer."""
-
-    return create_flat_buffer(
-        max_length=max_length,
-        min_length=min_length,
-        sample_batch_size=sample_batch_size,
-        add_sequences=add_sequences,
-        add_batch_size=add_batch_size,
-    )

--- a/flashbax/buffers/item_buffer.py
+++ b/flashbax/buffers/item_buffer.py
@@ -47,12 +47,12 @@ def validate_item_buffer_args(
     validate_min_length(min_length, max_length)
 
 
-def create_item_buffer(
+def make_item_buffer(
     max_length: int,
     min_length: int,
     sample_batch_size: int,
-    add_sequences: bool,
-    add_batches: bool,
+    add_sequences: bool = False,
+    add_batches: bool = False,
 ) -> TrajectoryBuffer:
     """Creates a trajectory buffer that acts as an independent item buffer.
 
@@ -115,35 +115,3 @@ def create_item_buffer(
         return TrajectoryBufferSample(experience=sampled_batch)
 
     return buffer.replace(add=add_fn, sample=sample_fn)  # type: ignore
-
-
-def make_item_buffer(
-    max_length: int,
-    min_length: int,
-    sample_batch_size: int,
-    add_sequences: bool = False,
-    add_batches: bool = False,
-) -> TrajectoryBuffer:
-    """Makes a trajectory buffer act as a independent item buffer.
-
-    Args:
-        max_length (int): The maximum length of the buffer.
-        min_length (int): The minimum length of the buffer.
-        sample_batch_size (int): The batch size of the samples.
-        add_sequences (Optional[bool], optional): Whether data is being added in sequences
-            to the buffer. If False, single items are being added each time add
-            is called. Defaults to False.
-        add_batches: (Optional[bool], optional): Whether adding data in batches to the buffer.
-            If False, single transitions or single sequences are being added each time add
-            is called. Defaults to False.
-
-    Returns:
-        The buffer."""
-
-    return create_item_buffer(
-        max_length=max_length,
-        min_length=min_length,
-        sample_batch_size=sample_batch_size,
-        add_sequences=add_sequences,
-        add_batches=add_batches,
-    )


### PR DESCRIPTION
- Remove make_flat_buffer in favor of create_flat_buffer
- Remove make_item_buffer in favor of create_item_buffer
- Rename create_flat_buffer to make_flat_buffer
- Rename create_item_buffer to make_item_buffer

Fixes issue #56