### PR TITLE
fix(vault): handle buffer full state when current_index resets to 0

### DIFF
--- a/flashbax/utils.py
+++ b/flashbax/utils.py
@@ -92,3 +92,15 @@ def get_timestep_count(buffer_state: chex.ArrayTree) -> int:
     )
     timestep_count: int = b_size * t_size
     return timestep_count
+
+
+def get_max_index(buffer_state: chex.ArrayTree) -> int:
+    """Utility to compute the maximum index of the buffer state.
+
+    Args:
+        buffer_state (BufferStateTypes): the buffer state to compute the maximum index for.
+
+    Returns:
+        int: the maximum index of the buffer state.
+    """
+    return get_tree_shape_prefix(buffer_state.experience, n_axes=2)[1]

--- a/flashbax/utils.py
+++ b/flashbax/utils.py
@@ -98,9 +98,10 @@ def get_max_index(buffer_state: chex.ArrayTree) -> int:
     """Utility to compute the maximum index of the buffer state.
 
     Args:
-        buffer_state (BufferStateTypes): the buffer state to compute the maximum index for.
+        buffer_state: the buffer state to compute the maximum index for.
 
     Returns:
         int: the maximum index of the buffer state.
     """
+    assert hasattr(buffer_state, "experience")
     return get_tree_shape_prefix(buffer_state.experience, n_axes=2)[1]

--- a/flashbax/vault/vault.py
+++ b/flashbax/vault/vault.py
@@ -368,9 +368,10 @@ class Vault:
                 and self._last_received_fbx_index == 0
             ):
                 warnings.warn(
-                    "Writing nothing: buffer is full and current_index is 0 and first write "
-                    "(last_received_fbx_index=0). If you want to write the entire buffer, "
-                    "you should specify source_interval explicitly.",
+                    "Writing nothing: Buffer is full and current_index has reset to 0, but this is the first write "
+                    "to vault (last_received_fbx_index=0). No data will be written. To write the "
+                    "entire buffer, specify source_interval explicitly: "
+                    "v.write(buffer_state, source_interval=(0, get_max_index(buffer_state)))",
                     UserWarning,
                     stacklevel=2,
                 )

--- a/flashbax/vault/vault.py
+++ b/flashbax/vault/vault.py
@@ -368,9 +368,9 @@ class Vault:
                 and self._last_received_fbx_index == 0
             ):
                 warnings.warn(
-                    "Writing nothing: Buffer is full and current_index has reset to 0, but this is the first write "
-                    "to vault (last_received_fbx_index=0). No data will be written. To write the "
-                    "entire buffer, specify source_interval explicitly: "
+                    "Writing nothing: Buffer is full and current_index has reset to 0, but this "
+                    "is the first write to vault (last_received_fbx_index=0). No data will be "
+                    "written. To write the entire buffer, specify source_interval explicitly: "
                     "v.write(buffer_state, source_interval=(0, get_max_index(buffer_state)))",
                     UserWarning,
                     stacklevel=2,

--- a/flashbax/vault/vault.py
+++ b/flashbax/vault/vault.py
@@ -15,10 +15,10 @@
 import asyncio
 import json
 import os
+import warnings
 from ast import literal_eval as make_tuple
 from datetime import datetime
 from typing import Optional, Tuple, Union
-import warnings
 
 import jax
 import jax.numpy as jnp

--- a/flashbax/vault/vault.py
+++ b/flashbax/vault/vault.py
@@ -18,6 +18,7 @@ import os
 from ast import literal_eval as make_tuple
 from datetime import datetime
 from typing import Optional, Tuple, Union
+import warnings
 
 import jax
 import jax.numpy as jnp
@@ -366,8 +367,13 @@ class Vault:
                 and fbx_current_index == 0
                 and self._last_received_fbx_index == 0
             ):
-                fbx_max_index = get_tree_shape_prefix(fbx_state.experience, n_axes=2)[1]
-                source_interval = (0, fbx_max_index)
+                warnings.warn(
+                    "Writing nothing: buffer is full and current_index is 0 and first write "
+                    "(last_received_fbx_index=0). If you want to write the entire buffer, "
+                    "you should specify source_interval explicitly.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             else:
                 source_interval = (self._last_received_fbx_index, fbx_current_index)
 

--- a/flashbax/vault/vault.py
+++ b/flashbax/vault/vault.py
@@ -359,7 +359,13 @@ class Vault:
 
         # By default, we read from `last received` to `current index`
         if source_interval == (0, 0):
-            source_interval = (self._last_received_fbx_index, fbx_current_index)
+            # Special case: if buffer is full and current_index is 0, and this is the first write
+            # (last_received_fbx_index is 0), we need to write the entire buffer
+            if fbx_state.is_full and fbx_current_index == 0 and self._last_received_fbx_index == 0:
+                fbx_max_index = get_tree_shape_prefix(fbx_state.experience, n_axes=2)[1]
+                source_interval = (0, fbx_max_index)
+            else:
+                source_interval = (self._last_received_fbx_index, fbx_current_index)
 
         # By default, we continue writing from the current vault index
         dest_start = self.vault_index if dest_start is None else dest_start

--- a/flashbax/vault/vault.py
+++ b/flashbax/vault/vault.py
@@ -361,7 +361,11 @@ class Vault:
         if source_interval == (0, 0):
             # Special case: if buffer is full and current_index is 0, and this is the first write
             # (last_received_fbx_index is 0), we need to write the entire buffer
-            if fbx_state.is_full and fbx_current_index == 0 and self._last_received_fbx_index == 0:
+            if (
+                fbx_state.is_full
+                and fbx_current_index == 0
+                and self._last_received_fbx_index == 0
+            ):
                 fbx_max_index = get_tree_shape_prefix(fbx_state.experience, n_axes=2)[1]
                 source_interval = (0, fbx_max_index)
             else:


### PR DESCRIPTION
- Add condition that ensure writing full buffer on first write
- Ensure data is not lost when buffer becomes full and index resets

this is the fix for issue @https://github.com/instadeepai/flashbax/issues/66